### PR TITLE
Suppress byte-compile warning

### DIFF
--- a/cbm.el
+++ b/cbm.el
@@ -44,6 +44,7 @@
 ;;; Code:
 (require 'cl-lib)
 
+(declare-function org-agenda-files "org")
 
 (defvar cbm-buffers nil
   "Holds current cycling-list.")


### PR DESCRIPTION
This change fixes a following byte-compile warning.

```
cbm.el:123:1:Warning: the function `org-agenda-files' is not known to be defined.
```
