### PR TITLE
Docs improvements and minibuffer prompt change

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-* cbm - Switch to "similiar" buffers.
+* cbm - Switch to similar buffers.
 
 ** Installation:
 
@@ -6,7 +6,7 @@
 
    (require 'cbm)
 
-   The package is also availaible via `melpa' or `melpa-stable.
+   The package is also available via `melpa' or `melpa-stable.
 
    It is recommended to bind `cbm-cycle', `cbm-switch-buffer' and
    `cbm-find-org-agenda-file', `cbm-rcirc-switch-to-channel' to a key:
@@ -18,6 +18,6 @@
 
 ** Usage:
 
-   This package provides one usefull commands for switching to
-   "similiar" buffers.
-
+   This package provides useful commands for switching to similar
+   buffers. It's particularly handy for switching between buffers in
+   the same major mode.

--- a/cbm.el
+++ b/cbm.el
@@ -104,7 +104,8 @@
                                       major-mode)))
                            (buffer-list))))))
     (switch-to-buffer
-     (completing-read "Switch to buffer: " buffer-list nil t))))
+     (completing-read (format "Switch to %s buffer: " mm)
+                      buffer-list nil t))))
 
 ;;;###autoload
 (defun cbm-find-org-agenda-file ()

--- a/cbm.el
+++ b/cbm.el
@@ -1,4 +1,4 @@
-;;; cbm.el --- Switch to "similiar" buffers.
+;;; cbm.el --- Switch to similar buffers.
 
 ;; Copyright 2015 Lukas Fürmetz
 
@@ -8,7 +8,7 @@
 ;; Version: 0.3
 ;; Keywords: buffers
 
-;; cmb.el is free software: you can redistribute it and/or modify
+;; cbm.el is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
@@ -39,8 +39,9 @@
 
 ;; Usage:
 
-;; This package provides one usefull commands for switching to
-;; "similiar" buffers.
+;; This package provides useful commands for switching to similar
+;; buffers. It's particularly handy for switching between buffers in
+;; the same major mode.
 
 ;;; Code:
 (require 'cl-lib)


### PR DESCRIPTION
This PR consists of two commits:
1. The first commit fixes a few spelling issues I noticed when reading through cbm.el.
2. The second commit improves the minibuffer prompt in `cbm-switch-buffer`. It now takes the form "Switch to emacs-lisp-mode buffer: " to make the behaviour more explicit.
